### PR TITLE
Allow default values even if axis_linear is defined

### DIFF
--- a/src/teleop_twist_joy.cpp
+++ b/src/teleop_twist_joy.cpp
@@ -74,30 +74,14 @@ TeleopTwistJoy::TeleopTwistJoy(ros::NodeHandle* nh, ros::NodeHandle* nh_param)
   nh_param->param<int>("enable_button", pimpl_->enable_button, 0);
   nh_param->param<int>("enable_turbo_button", pimpl_->enable_turbo_button, -1);
 
-  if (nh_param->getParam("axis_linear", pimpl_->axis_linear_map))
-  {
-    nh_param->getParam("scale_linear", pimpl_->scale_linear_map["normal"]);
-    nh_param->getParam("scale_linear_turbo", pimpl_->scale_linear_map["turbo"]);
-  }
-  else
-  {
-    nh_param->param<int>("axis_linear", pimpl_->axis_linear_map["x"], 1);
-    nh_param->param<double>("scale_linear", pimpl_->scale_linear_map["normal"]["x"], 0.5);
-    nh_param->param<double>("scale_linear_turbo", pimpl_->scale_linear_map["turbo"]["x"], 1.0);
-  }
+  nh_param->param<int>("axis_linear", pimpl_->axis_linear_map["x"], 1);
+  nh_param->param<double>("scale_linear", pimpl_->scale_linear_map["normal"]["x"], 0.5);
+  nh_param->param<double>("scale_linear_turbo", pimpl_->scale_linear_map["turbo"]["x"], 1.0);
 
-  if (nh_param->getParam("axis_angular", pimpl_->axis_angular_map))
-  {
-    nh_param->getParam("scale_angular", pimpl_->scale_angular_map["normal"]);
-    nh_param->getParam("scale_angular_turbo", pimpl_->scale_angular_map["turbo"]);
-  }
-  else
-  {
-    nh_param->param<int>("axis_angular", pimpl_->axis_angular_map["yaw"], 0);
-    nh_param->param<double>("scale_angular", pimpl_->scale_angular_map["normal"]["yaw"], 0.5);
-    nh_param->param<double>("scale_angular_turbo",
-        pimpl_->scale_angular_map["turbo"]["yaw"], pimpl_->scale_angular_map["normal"]["yaw"]);
-  }
+  nh_param->param<int>("axis_angular", pimpl_->axis_angular_map["yaw"], 0);
+  nh_param->param<double>("scale_angular", pimpl_->scale_angular_map["normal"]["yaw"], 0.5);
+  nh_param->param<double>("scale_angular_turbo",
+      pimpl_->scale_angular_map["turbo"]["yaw"], pimpl_->scale_angular_map["normal"]["yaw"]);
 
   ROS_INFO_NAMED("TeleopTwistJoy", "Teleop enable button %i.", pimpl_->enable_button);
   ROS_INFO_COND_NAMED(pimpl_->enable_turbo_button >= 0, "TeleopTwistJoy",


### PR DESCRIPTION
Potential fix for #33 

Currently, default scale values are not used if a non-default axis is used for either `axis_linear` or `axis_angular`. As a result, the cmd_vel topic will only command velocities of 0 for the affected axes. 

By removing the if-statement, the default values are still taken into account if another axis is used. 