### PR TITLE
need .cpp at end of src filename to avoid cmake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ catkin_package(
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 
-add_library(${PROJECT_NAME} src/${PROJECT_NAME})
+add_library(${PROJECT_NAME} src/${PROJECT_NAME}.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 add_executable(${PROJECT_NAME}_node src/teleop_node.cpp)


### PR DESCRIPTION
CMP0115 https://cmake.org/cmake/help/latest/policy/CMP0115.html

> Starting in CMake 3.20, CMake prefers all source files to have their extensions explicitly listed