### PR TITLE
Speed control added

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package teleop_twist_joy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.1.4 (2023-07-17)
+------------------
+* Added max speed control
+* Contributors: Hasan Ozcan
+
 0.1.3 (2019-01-21)
 ------------------
 * Use industrial ci


### PR DESCRIPTION
I added speed control buttons. This commitment includes increasing and decreasing maximum speed control. The speed can reach up to the turbo speeds set as the maximum and can be set to a minimum of 0.01. Buttons can be adjusted optionally with parameters.I would also like to edit the ros wiki if you accept.
